### PR TITLE
feat: add Portkey gateway support for Anthropic API

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ AICORE_MODEL_VERSION=latest
 
 The scripts load these via `python-dotenv`. Provider config is in `src/llms.py`.
 
+### Portkey Gateway (optional)
+
+To route API calls through [Portkey](https://portkey.ai), set:
+
+```bash
+PORTKEY_API_KEY=pk-...
+ANTHROPIC_BASE_URL=https://api.portkey.ai/v1
+```
+
+When both are set, the Anthropic client authenticates via Portkey's gateway using the
+`x-portkey-api-key` header. The Portkey API key's config (set in the Portkey dashboard)
+determines which upstream provider is used.
+
 For ABAP-1/BTP setup details, see [`docs/ABAP_1_BTP_SETUP.md`](docs/ABAP_1_BTP_SETUP.md).
 
 ---

--- a/src/batch_status.py
+++ b/src/batch_status.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 import openai
 import anthropic
 
-from llms import get_provider_api_key
+from llms import create_anthropic_client, get_provider_api_key
 import generate_llm_answers_batch_openai as openai_batch
 import generate_llm_answers_batch_anthropic as anthropic_batch
 
@@ -161,7 +161,7 @@ def main():
         check_openai_batches(openai_client, complete=args.complete)
     
     if not args.openai_only:
-        anthropic_client = anthropic.Anthropic(api_key=get_provider_api_key("ANTHROPIC"))
+        anthropic_client = create_anthropic_client()
         check_anthropic_batches(anthropic_client, complete=args.complete)
     
     print("\n" + "-" * 60)

--- a/src/llm_generate.py
+++ b/src/llm_generate.py
@@ -31,7 +31,11 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from llms import API_PROVIDERS, MODELS_TO_RUN, RunnableModel, get_provider_api_key
+from llms import (
+    API_PROVIDERS, MODELS_TO_RUN, RunnableModel,
+    create_anthropic_client, create_portkey_openai_client,
+    get_provider_api_key, is_portkey_anthropic,
+)
 from generate_llm_answers_parallel import DailyQuotaExhausted
 from chat_state import (
     print_status,
@@ -97,12 +101,14 @@ def mode_complete_pending(model_name: str, model_info: RunnableModel):
     """Complete any pending batch jobs for this model's provider."""
     provider = model_info["provider"]
 
-    if provider == "ANTHROPIC":
+    if provider == "ANTHROPIC" and is_portkey_anthropic():
+        print(f"[SKIP] ANTHROPIC via Portkey uses parallel runner, not batch processing.")
+
+    elif provider == "ANTHROPIC":
         import anthropic
         import generate_llm_answers_batch_anthropic as gen
 
-        api_key = get_provider_api_key(provider)
-        client = anthropic.Anthropic(api_key=api_key)
+        client = create_anthropic_client()
         completed = gen.check_and_complete_pending_batches(client, model_info["name"])
         if completed:
             print(f"[DONE] Completed {len(completed)} pending Anthropic batch(es)")
@@ -172,12 +178,17 @@ def mode_first(model_name: str, model_info: RunnableModel):
     save_file_batch = f"data/{model_name.replace(':', '_')}_batch.jsonl"
     save_file_batch_response = save_file_batch[:-6] + "_response.jsonl"
 
-    if provider == "ANTHROPIC":
+    if provider == "ANTHROPIC" and is_portkey_anthropic():
+        import generate_llm_answers_parallel as gen
+
+        llm_client = create_portkey_openai_client(async_client=True)
+        asyncio.run(gen.generate_first_response(llm_client, model_info))
+
+    elif provider == "ANTHROPIC":
         import anthropic
         import generate_llm_answers_batch_anthropic as gen
 
-        api_key = get_provider_api_key(provider)
-        client = anthropic.Anthropic(api_key=api_key)
+        client = create_anthropic_client()
 
         batch_id = gen.generate_first_response_batch(
             client, model_info, save_file_batch, save_file
@@ -351,12 +362,19 @@ def mode_next(model_name: str, model_info: RunnableModel):
                     max_round = r
     round_num = max_round  # the round about to be generated
 
-    if provider == "ANTHROPIC":
+    if provider == "ANTHROPIC" and is_portkey_anthropic():
+        import generate_llm_answers_parallel as gen
+
+        llm_client = create_portkey_openai_client(async_client=True)
+        asyncio.run(
+            gen.generate_next_response(llm_client, model_info, round_num)
+        )
+
+    elif provider == "ANTHROPIC":
         import anthropic
         import generate_llm_answers_batch_anthropic as gen
 
-        api_key = get_provider_api_key(provider)
-        client = anthropic.Anthropic(api_key=api_key)
+        client = create_anthropic_client()
 
         batch_id = gen.generate_next_response_batch(
             client, model_info, save_file, save_file_batch, round_num=round_num

--- a/src/llms.py
+++ b/src/llms.py
@@ -42,6 +42,50 @@ def get_provider_api_key(provider_name: str) -> str:
     )
 
 
+# Optional Portkey gateway.  Set PORTKEY_API_KEY and point a provider's
+# base URL at Portkey to route it through the gateway.  Example .env:
+#   PORTKEY_API_KEY=pk-...
+#   ANTHROPIC_BASE_URL=https://api.portkey.ai
+# For OpenAI-compatible providers (Groq, Mistral, …) no code change is
+# needed — just override their base URL and API key in .env.
+PORTKEY_API_KEY = _env("PORTKEY_API_KEY")
+
+
+def is_portkey_anthropic() -> bool:
+    """True when Anthropic is routed through Portkey (batch API unavailable)."""
+    return bool(PORTKEY_API_KEY and API_PROVIDERS["ANTHROPIC"].get("base_url"))
+
+
+def create_portkey_openai_client(async_client: bool = False):
+    """Create an OpenAI client pointed at the Portkey gateway."""
+    import openai
+
+    base_url = API_PROVIDERS["ANTHROPIC"].get("base_url")
+    if async_client:
+        return openai.AsyncOpenAI(api_key=PORTKEY_API_KEY, base_url=base_url)
+    return openai.OpenAI(api_key=PORTKEY_API_KEY, base_url=base_url)
+
+
+def create_anthropic_client(async_client: bool = False):
+    """Create an Anthropic client, routing through Portkey if configured."""
+    import anthropic
+
+    cls = anthropic.AsyncAnthropic if async_client else anthropic.Anthropic
+    base_url = API_PROVIDERS["ANTHROPIC"].get("base_url")
+    if PORTKEY_API_KEY and base_url:
+        # Anthropic SDK appends /v1/… itself, so strip trailing /v1
+        portkey_url = base_url.removesuffix("/v1").removesuffix("/")
+        return cls(
+            api_key="portkey",  # placeholder; real auth via header
+            base_url=portkey_url,
+            default_headers={"x-portkey-api-key": PORTKEY_API_KEY},
+        )
+    api_key = get_provider_api_key("ANTHROPIC")
+    if base_url:
+        return cls(api_key=api_key, base_url=base_url)
+    return cls(api_key=api_key)
+
+
 API_PROVIDERS: Dict[str, ModelProvider] = {
     "GROQ": {
         "base_url": "https://api.groq.com/openai/v1",
@@ -54,7 +98,7 @@ API_PROVIDERS: Dict[str, ModelProvider] = {
         "api_key": _env("MISTRAL_API_KEY"),
     },
     "ANTHROPIC": {
-        "base_url": "https://api.anthropic.com/v1/",
+        "base_url": _env("ANTHROPIC_BASE_URL") or None,
         "api_key_env": "ANTHROPIC_API_KEY",
         "api_key": _env("ANTHROPIC_API_KEY"),
     },

--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,11 @@ import generate_llm_answers_parallel
 import generate_llm_answers_openai_direct
 import generate_llm_answers_openai_responses
 from generate_llm_answers_parallel import DailyQuotaExhausted
-from llms import API_PROVIDERS, MODELS_TO_RUN, RunnableModel, get_provider_api_key
+from llms import (
+    API_PROVIDERS, MODELS_TO_RUN, RunnableModel,
+    create_anthropic_client, create_portkey_openai_client,
+    get_provider_api_key, is_portkey_anthropic,
+)
 
 
 def get_available_models():
@@ -84,7 +88,7 @@ def batch_openai(model_info: RunnableModel):
 
 
 def batch_anthropic(model_info: RunnableModel):
-    client = anthropic.Anthropic(api_key=get_provider_api_key(model_info["provider"]))
+    client = create_anthropic_client()
     save_file = f"data/{model_info['name']}.json"
     save_file_batch = f"{save_file[:-5]}_batch.jsonl"
     save_file_batch_response = save_file_batch[:-6] + "_response.jsonl"
@@ -259,6 +263,8 @@ def run_parrallel_model(model_info: RunnableModel):
             temperature=model_info["temperature"],
             max_tokens=model_info["max_tokens"],
         )
+    elif is_portkey_anthropic() and model_info["provider"] == "ANTHROPIC":
+        client = create_portkey_openai_client(async_client=True)
     else:
         provider = API_PROVIDERS[model_info["provider"]]
         client = openai.AsyncOpenAI(
@@ -374,7 +380,9 @@ if __name__ == "__main__":
         print(f"{'='*60}")
 
         try:
-            if model_info["provider"] == "ANTHROPIC":
+            if model_info["provider"] == "ANTHROPIC" and is_portkey_anthropic():
+                run_parrallel_model(model_info)
+            elif model_info["provider"] == "ANTHROPIC":
                 batch_anthropic(model_info)
             elif model_info["provider"] == "OPENAI":
                 batch_openai(model_info)

--- a/src/smoke_test.py
+++ b/src/smoke_test.py
@@ -8,7 +8,10 @@ import sys
 from openai import OpenAI
 import anthropic
 
-from llms import API_PROVIDERS, MODELS_TO_RUN, get_provider_api_key
+from llms import (
+    API_PROVIDERS, MODELS_TO_RUN,
+    create_anthropic_client, get_provider_api_key,
+)
 
 
 def test_openai_compatible(model_name: str, provider_name: str, base_url: str, api_key: str) -> tuple[bool, str]:
@@ -39,10 +42,10 @@ def test_openai_compatible(model_name: str, provider_name: str, base_url: str, a
         return False, str(e)
 
 
-def test_anthropic(model_name: str, api_key: str) -> tuple[bool, str]:
-    """Test Anthropic API."""
+def test_anthropic(model_name: str) -> tuple[bool, str]:
+    """Test Anthropic API (direct or via Portkey)."""
     try:
-        client = anthropic.Anthropic(api_key=api_key)
+        client = create_anthropic_client()
         response = client.messages.create(
             model=model_name,
             max_tokens=10,
@@ -147,12 +150,7 @@ def main():
         if provider_name == "SAP_AICORE":
             success, message = test_sap_aicore(model_name)
         elif provider_name == "ANTHROPIC":
-            try:
-                api_key = get_provider_api_key(provider_name)
-            except RuntimeError as e:
-                success, message = False, str(e)
-            else:
-                success, message = test_anthropic(model_name, api_key)
+            success, message = test_anthropic(model_name)
         elif provider_name == "OPENAI_RESPONSES":
             try:
                 api_key = get_provider_api_key(provider_name)

--- a/src/understanding_batch.py
+++ b/src/understanding_batch.py
@@ -32,7 +32,7 @@ from typing import Any, Dict, List, Optional
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from llms import API_PROVIDERS, RunnableModel, get_provider_api_key
+from llms import API_PROVIDERS, RunnableModel, create_anthropic_client, get_provider_api_key
 from understanding_eval import (
     FEEDBACK_PROMPT,
     REPO_ROOT,
@@ -162,7 +162,7 @@ def _build_sync_client(model_info: RunnableModel):
     if provider == "ANTHROPIC":
         import anthropic
 
-        return anthropic.Anthropic(api_key=get_provider_api_key(provider))
+        return create_anthropic_client()
 
     if provider == "MISTRAL":
         from mistralai import Mistral

--- a/src/understanding_eval.py
+++ b/src/understanding_eval.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 load_dotenv()
 
-from llms import API_PROVIDERS, MODELS_TO_RUN, RunnableModel, get_provider_api_key
+from llms import API_PROVIDERS, MODELS_TO_RUN, RunnableModel, create_anthropic_client, get_provider_api_key
 from abap1_orchestration import ABAP1OrchestrationClient
 
 
@@ -406,10 +406,7 @@ async def _build_client(model_info: RunnableModel) -> Any:
         )
 
     if provider == "ANTHROPIC":
-        import anthropic
-
-        api_key = get_provider_api_key(provider)
-        return anthropic.AsyncAnthropic(api_key=api_key)
+        return create_anthropic_client(async_client=True)
 
     import openai
 


### PR DESCRIPTION
Optional PR as I don't use a standalone API key.

Route Anthropic API calls through Portkey when PORTKEY_API_KEY and ANTHROPIC_BASE_URL are set. The Anthropic SDK works natively through Portkey for single messages; batch API calls fall back to the parallel runner since Portkey doesn't proxy the batch endpoint.

Centralizes Anthropic client creation in create_anthropic_client() so all call sites benefit. Without Portkey env vars, behavior is unchanged.